### PR TITLE
修改drawing.py中坐标变换的部分.

### DIFF
--- a/cnmaps/drawing.py
+++ b/cnmaps/drawing.py
@@ -18,8 +18,9 @@ def _make_clip_path(map_polygon):
     codes = []
     ax = plt.gca()
     clips = []
+    crs = ccrs.PlateCarree()
 
-    for polygon in map_polygon:
+    for polygon in map_polygon.geoms:
         try:
             coords = polygon.boundary.coords
         except NotImplementedError:
@@ -29,8 +30,7 @@ def _make_clip_path(map_polygon):
             exterior_prt = len(exterior_coords)
             for coord in exterior_coords:
                 try:
-                    trans_coord = ax.projection.transform_point(
-                        *coord, src_crs=ccrs.PlateCarree())
+                    trans_coord = ax.projection.transform_point(*coord, crs)
                 except AttributeError:
                     trans_coord = coord
                 vertices.append(trans_coord)
@@ -42,8 +42,7 @@ def _make_clip_path(map_polygon):
                 interior_prt = len(interior_coords)
                 for coord in interior_coords:
                     try:
-                        trans_coord = ax.projection.transform_point(
-                            *coord, src_crs=ccrs.PlateCarree())
+                        trans_coord = ax.projection.transform_point(*coord, crs)
                     except AttributeError:
                         trans_coord = coord
                     vertices.append(trans_coord)
@@ -56,8 +55,7 @@ def _make_clip_path(map_polygon):
             prt = len(coords)
             for coord in coords:
                 try:
-                    trans_coord = ax.projection.transform_point(
-                        *coord, src_crs=ccrs.PlateCarree())
+                    trans_coord = ax.projection.transform_point(*coord, crs)
                 except AttributeError:
                     trans_coord = coord
                 vertices.append(trans_coord)
@@ -187,11 +185,12 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text,
     >>> draw_map(map_polygon, color='k')
     """
     ax = plt.gca()
+    crs = ccrs.PlateCarree()
 
     for cbt in clabel_text:
         cbt.set_visible(False)
 
-    for polygon in map_polygon:
+    for polygon in map_polygon.geoms:
         vertices = []
         try:
             coords = polygon.boundary.coords
@@ -202,8 +201,7 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text,
             interiors = polygon.interiors
             for coord in exterior_coords:
                 try:
-                    trans_coord = ax.projection.transform_point(
-                        *coord, src_crs=ccrs.PlateCarree())
+                    trans_coord = ax.projection.transform_point(*coord, crs)
                 except AttributeError:
                     trans_coord = coord
                 vertices.append(trans_coord)
@@ -212,8 +210,7 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text,
                 interior_coords = interior.coords
                 for coord in interior_coords:
                     try:
-                        trans_coord = ax.projection.transform_point(
-                            *coord, src_crs=ccrs.PlateCarree())
+                        trans_coord = ax.projection.transform_point(*coord, crs)
                     except AttributeError:
                         trans_coord = coord
                     hole.append(trans_coord)
@@ -222,8 +219,7 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text,
         else:
             for coord in coords:
                 try:
-                    trans_coord = ax.projection.transform_point(
-                        *coord, src_crs=ccrs.PlateCarree())
+                    trans_coord = ax.projection.transform_point(*coord, crs)
                 except AttributeError:
                     trans_coord = coord
                 vertices.append(trans_coord)
@@ -258,13 +254,14 @@ def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
         >>> draw_map(get_adm_maps(city='北京市', level='市', only_polygon=True, record='first'))
     """
     ax = plt.gca()
-    for geomestry in map_polygon:
+    crs = ccrs.PlateCarree()
+    for geometry in map_polygon.geoms:
         if isinstance(map_polygon, sgeom.MultiPolygon):
             try:
-                coords = geomestry.boundary.coords
+                coords = geometry.boundary.coords
             except NotImplementedError:
-                exterior_coords = geomestry.exterior.coords
-                interiors = geomestry.interiors
+                exterior_coords = geometry.exterior.coords
+                interiors = geometry.interiors
                 xs = []
                 ys = []
                 for coord in exterior_coords:
@@ -283,8 +280,7 @@ def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
                     ys = []
                     for coord in interior_coords:
                         try:
-                            x, y = ax.projection.transform_point(
-                                *coord, src_crs=ccrs.PlateCarree())
+                            x, y = ax.projection.transform_point(*coord, crs)
                         except AttributeError:
                             x, y = coord
                         xs.append(x)
@@ -292,13 +288,12 @@ def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
                     ax.plot(xs, ys, **kwargs)
                 continue
         elif isinstance(map_polygon, sgeom.MultiLineString):
-            coords = geomestry.coords
+            coords = geometry.coords
         xs = []
         ys = []
         for coord in coords:
             try:
-                x, y = ax.projection.transform_point(
-                    *coord, src_crs=ccrs.PlateCarree())
+                x, y = ax.projection.transform_point(*coord, src_crs=crs)
             except AttributeError:
                 x, y = coord
             xs.append(x)

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,0 +1,78 @@
+import time
+
+import shapely.geometry as sgeom
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+from cnmaps import get_adm_maps, draw_maps
+
+def draw_map_new(map_polygon, **kwargs):
+    '''提前创建crs后的draw_map函数.'''
+    ax = plt.gca()
+    crs = ccrs.PlateCarree()
+    for geomestry in map_polygon:
+        if isinstance(map_polygon, sgeom.MultiPolygon):
+            try:
+                coords = geomestry.boundary.coords
+            except NotImplementedError:
+                exterior_coords = geomestry.exterior.coords
+                interiors = geomestry.interiors
+                xs = []
+                ys = []
+                for coord in exterior_coords:
+                    try:
+                        x, y = ax.projection.transform_point(*coord, crs)
+                    except AttributeError:
+                        x, y = coord
+                    xs.append(x)
+                    ys.append(y)
+
+                ax.plot(xs, ys, **kwargs)
+                for interior in interiors:
+                    interior_coords = interior.coords
+                    xs = []
+                    ys = []
+                    for coord in interior_coords:
+                        try:
+                            x, y = ax.projection.transform_point(*coord, crs)
+                        except AttributeError:
+                            x, y = coord
+                        xs.append(x)
+                        ys.append(y)
+                    ax.plot(xs, ys, **kwargs)
+                continue
+        elif isinstance(map_polygon, sgeom.MultiLineString):
+            coords = geomestry.coords
+        xs = []
+        ys = []
+        for coord in coords:
+            try:
+                x, y = ax.projection.transform_point(*coord, crs)
+            except AttributeError:
+                x, y = coord
+            xs.append(x)
+            ys.append(y)
+        if kwargs.get('color'):
+            ax.plot(xs, ys, **kwargs)
+        else:
+            ax.plot(xs, ys, color='k', **kwargs)
+
+def runtime(func, *args, **kwargs):
+    '''打印函数运行的时间.'''
+    t0 = time.time()
+    result = func(*args, **kwargs)
+    t1 = time.time()
+    print('>> Time used by', func.__name__, ':', t1 - t0, 's')
+
+    return result
+
+crs = ccrs.PlateCarree()
+fig = plt.figure()
+ax = fig.add_subplot(111, projection=crs)
+
+hebei = get_adm_maps(province='河北省')
+runtime(draw_maps, hebei)
+
+hebei = hebei[0]['geometry']
+runtime(draw_map_new, hebei)
+
+plt.show()


### PR DESCRIPTION
- `draw_map` 和 `clip` 相关函数在开头就创建 `CRS` 对象，避免循环创建。
- `draw_map` 中的错字 `geomestry` 改为 `geometry`。
- 对于 2.0 以上的 Shapely 包，直接对 `MultiPolygon` 进行迭代会产生 `ShapelyDeprecationWarning`，所以将 `draw_map` 和 `clip` 相关函数中的 `for polygon in map_polygon:` 改为 `for polygon in map_polygon.geoms`。